### PR TITLE
Add debug build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,23 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  build:
-    name: build-${{ matrix.os }}
+  build-debug:
+    name: build-debug-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --verbose
+
+  build-release:
+    name: build-release-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Adds a debug build mode to CI. CI now runs builds and tests in both debug and release modes.

Resolves: #6

<!--
Fuyu projects use a freeform pull request template, so we rely on contributors to read these brief instructions before submitting a pull request.

- If solving a bug or adding a feature, please submit an issue first that will be addressed by the pull request.
- Follow the Fuyu code conventions (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#code-conventions).
- Follow the pull request guidelines (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#pull-requests).
-->
