### PR TITLE
Add `include` to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,12 @@ description = "The Fuyu programming language"
 homepage = "https://fuyulang.dev"
 repository = "https://github.com/fuyulang/fuyu"
 license = "MPL-2.0"
+license_file = "LICENSE"
 keywords = ["concurrent", "functional"]
 categories = ["compilers", "concurrency"]
+include = [
+  "/Cargo.toml",
+  "/LICENSE",
+  "/README.md",
+  "/src/**/*.rs",
+]


### PR DESCRIPTION
Add the `package.include` key to `Cargo.toml` to include only the relevant files that Cargo needs to publish the crate.

Resolves: #1

<!--
Fuyu projects use a freeform pull request template, so we rely on contributors to read these brief instructions before submitting a pull request.

- If solving a bug or adding a feature, please submit an issue first that will be addressed by the pull request.
- Follow the Fuyu code conventions (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#code-conventions).
- Follow the pull request guidelines (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#pull-requests).
-->
