### PR TITLE
Remove license-file from manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "The Fuyu programming language"
 homepage = "https://fuyulang.dev"
 repository = "https://github.com/fuyulang/fuyu"
 license = "MPL-2.0"
-license_file = "LICENSE"
 keywords = ["concurrent", "functional"]
 categories = ["compilers", "concurrency"]
 include = [


### PR DESCRIPTION
Remove the `license-file` field from `Crago.toml` to resolve #10.

<!--
Fuyu projects use a freeform pull request template, so we rely on contributors to read these brief instructions before submitting a pull request.

- If solving a bug or adding a feature, please submit an issue first that will be addressed by the pull request.
- Follow the Fuyu code conventions (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#code-conventions).
- Follow the pull request guidelines (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#pull-requests).
-->
