### PR TITLE
Update AST with the new implicit syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ include = [
   "/Cargo.toml",
   "/LICENSE",
   "/README.md",
-  "/src/**/*.lalrpop",
   "/src/**/*.rs",
 ]

--- a/README.md
+++ b/README.md
@@ -10,13 +10,8 @@
 Fuyu is a concurrent functional programming language.
 
 > [!IMPORTANT]
-> The compiler is being
-> [bootstrapped](https://en.wikipedia.org/wiki/Bootstrapping_(compilers))
-> in Rust so that it can be
-> [self-hosted](https://en.wikipedia.org/wiki/Self-hosting_(compilers))
-> in Fuyu.
->
-> This means that the compiler is under development and is not ready for use.
+> The compiler is under development and does not have a release that is ready
+> for use.
 
 ## Contributing
 

--- a/src/ast/decl.rs
+++ b/src/ast/decl.rs
@@ -125,15 +125,9 @@ pub enum ImportDeclItem<'text> {
         rename: Option<Ident<'text>>,
     },
 
-    /// The `*` import.
-    Glob {
-        #[doc = docs!(span: "`*`")]
-        span: Span,
-    },
-
-    /// Import of a provision by name with a `use` prefix.
+    /// Import of a provision by name with a `provide` prefix.
     NamedProvision {
-        #[doc = docs!(span: "named provision"; including: "`use`", "rename")]
+        #[doc = docs!(span: "named provision"; including: "`provide`", "rename")]
         span: Span,
         #[doc = docs!(name: "item to import")]
         name: Ident<'text>,
@@ -141,20 +135,14 @@ pub enum ImportDeclItem<'text> {
         rename: Option<Ident<'text>>,
     },
 
-    /// Import of a provision by type with a `use` prefix.
+    /// Import of a provision by type with a `provide` prefix.
     ///
     /// Note that this type of import item cannot be renamed.
     TypedProvision {
-        #[doc = docs!(span: "typed provision"; including: "`use`")]
+        #[doc = docs!(span: "typed provision"; including: "`provide`")]
         span: Span,
         #[doc = docs!(type_name: "typed provision")]
         type_name: TypeName<'text>,
-    },
-
-    /// The `use *` import.
-    GlobProvision {
-        #[doc = docs!(span: "`use *`")]
-        span: Span,
     },
 }
 
@@ -315,11 +303,11 @@ pub struct FnDeclArg<'text> {
 /// # Form examples
 ///
 /// ```fuyu
-/// provide Emphasis = Strong;
-/// provide emphasis: Emphasis = Strong;
-/// provide (use a: A): B = B(10 * a.0);
-/// provide b_value(use a: A): B = B(10 * a.0);
-/// provide (use A): B = something_that_uses();
+/// provide Emphasis => Strong;
+/// provide emphasis: Emphasis => Strong;
+/// provide (use a: A): B => B(10 * a.0);
+/// provide b_value(use a: A): B => B(10 * a.0);
+/// provide (use A): B => something_that_uses();
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProvideDecl<'text> {


### PR DESCRIPTION
Use the new implicit syntax (closes #51).

- Change provisions to use `=>` instead of `=` to better capture that they are running code and are not a constant.
- Change `use` to `provide` in imports.
- Remove glob `*` imports.
- Remove glob `use *` imports.

<!--
Fuyu projects use a freeform pull request template, so we rely on contributors to read these brief instructions before submitting a pull request.

- If solving a bug or adding a feature, please submit an issue first that will be addressed by the pull request.
- Follow the Fuyu code conventions (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#code-conventions).
- Follow the pull request guidelines (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#pull-requests).
-->
