### PR TITLE
Add require, try, panic family, and attributes

### DIFF
--- a/fuyu-core/src/ast/decl.rs
+++ b/fuyu-core/src/ast/decl.rs
@@ -38,6 +38,22 @@ pub enum Visibility {
     Public,
 }
 
+/// An attribute.
+///
+/// # Form examples
+///
+/// ```fuyu
+/// @[x]
+/// @[f(1, 2, 3)]
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct Attribute<'text> {
+    #[doc = docs!(span: "attribute")]
+    pub span: Span,
+    #[doc = docs!(attribute)]
+    pub expr: Expr<'text>,
+}
+
 /// An import declaration.
 ///
 /// # Form examples
@@ -45,8 +61,8 @@ pub enum Visibility {
 /// ```fuyu
 /// import a/b/c;
 /// import a/b/c::x;
-/// import a/b/c::{self as m, type T, T as V, use *};
-/// import a/b/c::{use ctx, use Add[_]};
+/// import a/b/c::{type T, T as V, provide _};
+/// import a/b/c::{provide ctx, provide Add[_]};
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct ImportDecl<'text> {
@@ -58,6 +74,10 @@ pub struct ImportDecl<'text> {
     pub path: &'text str,
     #[doc = docs!(import: "items")]
     pub items: Vec<ImportDeclItem<'text>>,
+    #[doc = docs!(name: "renamed namespace")]
+    pub rename: Option<Ident<'text>>,
+    #[doc = docs!(attributes: "import")]
+    pub attributes: Vec<Attribute<'text>>,
 }
 
 /// The path settings for an import.
@@ -92,19 +112,11 @@ pub enum ImportDeclPathKind {
 /// # Form examples
 ///
 /// ```fuyu
-/// import a/b/c::{self as m, type T, T as V, use *};
-/// //             ^^^^^^^^^  ^^^^^^  ^^^^^^  ^^^^^
+/// import a/b/c::{type T, T as V, provide _} as m;
+/// //             ^^^^^^  ^^^^^^  ^^^^^^^^^
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub enum ImportDeclItem<'text> {
-    /// The `self` keyword.
-    ModuleSelf {
-        #[doc = docs!(span: "self import"; including: "rename")]
-        span: Span,
-        #[doc = docs!(name: "imported item")]
-        rename: Option<Ident<'text>>,
-    },
-
     /// Import of a value by name.
     Value {
         #[doc = docs!(span: "value import"; including: "rename")]
@@ -165,6 +177,8 @@ pub struct ConstDecl<'text> {
     pub type_name: TypeName<'text>,
     #[doc = docs!(expr: "constant")]
     pub expr: Expr<'text>,
+    #[doc = docs!(attributes: "constant")]
+    pub attributes: Vec<Attribute<'text>>,
 }
 
 /// A type declaration.
@@ -190,6 +204,8 @@ pub struct TypeDecl<'text> {
     pub type_name: TypeName<'text>,
     #[doc = docs!(constructors)]
     pub constructors: Vec<TypeDeclConstructor<'text>>,
+    #[doc = docs!(attributes: "type")]
+    pub attributes: Vec<Attribute<'text>>,
 }
 
 /// A constructor in a type declaration.
@@ -265,9 +281,11 @@ pub struct FnDecl<'text> {
     #[doc = docs!(return_type)]
     pub return_type: Option<TypeName<'text>>,
     #[doc = docs!(exprs: "function")]
-    pub exprs: Vec<Expr<'text>>,
+    pub exprs: Option<Vec<Expr<'text>>>,
     #[doc = docs!(evaluate_last)]
     pub evaluate_last: bool,
+    #[doc = docs!(attributes: "function")]
+    pub attributes: Vec<Attribute<'text>>,
 }
 
 /// An argument in a function declaration.
@@ -323,6 +341,8 @@ pub struct ProvideDecl<'text> {
     pub type_name: TypeName<'text>,
     #[doc = docs!(expr: "provisioned value")]
     pub expr: Expr<'text>,
+    #[doc = docs!(attributes: "provision")]
+    pub attributes: Vec<Attribute<'text>>,
 }
 
 /// Implicit arguments to a provide declaration.

--- a/fuyu-core/src/ast/expr.rs
+++ b/fuyu-core/src/ast/expr.rs
@@ -18,9 +18,15 @@
 //! - Parenthesized expressions ([`ParenExpr`]).
 //! - If expressions ([`IfExpr`]).
 //! - Match expressions ([`MatchExpr`]).
-//! - Return expressions ([`ReturnExpr`]).
+//! - Try expressions ([`TryExpr`]).
 //! - Let expressions ([`LetExpr`]).
+//! - Require expressions ([`RequireExpr`]).
 //! - Provide expressions ([`ProvideExpr`]).
+//! - Return expressions ([`ReturnExpr`]).
+//! - Panic expressions ([`PanicExpr`]).
+//! - Todo expressions ([`TodoExpr`]).
+//! - Unimplemented expressions ([`UnimplementedExpr`]).
+//! - Unreachable expressions ([`UnreachableExpr`]).
 //!
 //! Expressions can generally be composed, thus, the [`Expr`] enum represents any expression.
 
@@ -64,12 +70,24 @@ pub enum Expr<'text> {
     If(IfExpr<'text>),
     /// A match expression (refer to [`MatchExpr`]).
     Match(MatchExpr<'text>),
-    /// A return expression (refer to [`ReturnExpr`]).
-    Return(ReturnExpr<'text>),
+    /// A try expression (refer to [`TryExpr`]).
+    Try(TryExpr<'text>),
     /// A let expression (refer to [`LetExpr`]).
     Let(LetExpr<'text>),
+    /// A require expression (refer to [`RequireExpr`]).
+    Require(RequireExpr<'text>),
     /// A provide expression (refer to [`ProvideExpr`]).
     Provide(ProvideExpr<'text>),
+    /// A return expression (refer to [`ReturnExpr`]).
+    Return(ReturnExpr<'text>),
+    /// A provide expression (refer to [`PanicExpr`]).
+    Panic(PanicExpr<'text>),
+    /// A provide expression (refer to [`TodoExpr`]).
+    Todo(TodoExpr<'text>),
+    /// A provide expression (refer to [`UnimplementedExpr`]).
+    Unimplemented(UnimplementedExpr<'text>),
+    /// A provide expression (refer to [`UnreachableExpr`]).
+    Unreachable(UnreachableExpr<'text>),
 }
 
 /// An integer literal.
@@ -433,6 +451,8 @@ pub struct PrefixExpr<'text> {
 pub enum PrefixOp {
     /// `!`.
     Bang,
+    /// `..`.
+    DotDot,
     /// `-`.
     Minus,
 }
@@ -586,6 +606,24 @@ pub struct MatchClause<'text> {
     pub expr: Box<Expr<'text>>,
 }
 
+/// A try expression.
+///
+/// # Form examples
+///
+/// ```fuyu
+/// try value
+/// try f(1, 2, 3)
+/// x | try g("abc")
+/// //  ^^^^^^^^^^^^
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct TryExpr<'text> {
+    #[doc = docs!(span: "try")]
+    pub span: Span,
+    #[doc = docs!(expr: "try")]
+    pub expr: Box<Expr<'text>>,
+}
+
 /// A return expression.
 ///
 /// # Form examples
@@ -599,7 +637,7 @@ pub struct ReturnExpr<'text> {
     #[doc = docs!(span: "return")]
     pub span: Span,
     #[doc = docs!(expr: "return")]
-    pub expr: Box<Expr<'text>>,
+    pub expr: Option<Box<Expr<'text>>>,
 }
 
 /// A let expression.
@@ -619,6 +657,26 @@ pub struct LetExpr<'text> {
     #[doc = docs!(type_name: "let binding")]
     pub type_name: Option<TypeName<'text>>,
     #[doc = docs!(expr: "let binding")]
+    pub expr: Box<Expr<'text>>,
+}
+
+/// A require expression.
+///
+/// # Form examples
+///
+/// ```fuyu
+/// require a = 5
+/// require (x, y) = (3, 4)
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct RequireExpr<'text> {
+    #[doc = docs!(span: "require binding")]
+    pub span: Span,
+    #[doc = docs!(pattern: "require binding")]
+    pub pattern: Pattern<'text>,
+    #[doc = docs!(type_name: "require binding")]
+    pub type_name: Option<TypeName<'text>>,
+    #[doc = docs!(expr: "require binding")]
     pub expr: Box<Expr<'text>>,
 }
 
@@ -667,4 +725,68 @@ pub struct ProvideArg<'text> {
     ident: Option<Ident<'text>>,
     #[doc = docs!(type_name: "argument")]
     type_name: TypeName<'text>,
+}
+
+/// A panic expression.
+///
+/// # Form examples
+///
+/// ```fuyu
+/// panic
+/// panic "with a message"
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct PanicExpr<'text> {
+    #[doc = docs!(span: "panic")]
+    pub span: Span,
+    #[doc = docs!(expr: "panic")]
+    pub expr: Option<Box<Expr<'text>>>,
+}
+
+/// A todo expression.
+///
+/// # Form examples
+///
+/// ```fuyu
+/// todo
+/// todo "with a message"
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct TodoExpr<'text> {
+    #[doc = docs!(span: "todo")]
+    pub span: Span,
+    #[doc = docs!(expr: "todo")]
+    pub expr: Option<Box<Expr<'text>>>,
+}
+
+/// A unimplemented expression.
+///
+/// # Form examples
+///
+/// ```fuyu
+/// unimplemented
+/// unimplemented "with a message"
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct UnimplementedExpr<'text> {
+    #[doc = docs!(span: "unimplemented")]
+    pub span: Span,
+    #[doc = docs!(expr: "unimplemented")]
+    pub expr: Option<Box<Expr<'text>>>,
+}
+
+/// A unreachable expression.
+///
+/// # Form examples
+///
+/// ```fuyu
+/// unreachable
+/// unreachable "with a message"
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct UnreachableExpr<'text> {
+    #[doc = docs!(span: "unreachable")]
+    pub span: Span,
+    #[doc = docs!(expr: "unreachable")]
+    pub expr: Option<Box<Expr<'text>>>,
 }

--- a/fuyu-core/src/ast/util.rs
+++ b/fuyu-core/src/ast/util.rs
@@ -7,6 +7,12 @@ macro_rules! docs {
     (args: $about:expr) => {
         concat!("The arguments to the ", $about, ".\n")
     };
+    (attribute) => {
+        concat!("The attribute body.\n")
+    };
+    (attributes: $about:expr) => {
+        concat!("The attributes attached to the ", $about, ".\n")
+    };
     (block_arg) => {
         concat!("The block argument to the function call.\n")
     };

--- a/fuyu-core/src/parse/lexer.rs
+++ b/fuyu-core/src/parse/lexer.rs
@@ -278,6 +278,7 @@ impl<'a> Lexer<'a> {
             [Some('|'), Some('|'), ..] => self.advance_by_and_emit(2, Token::PipePipe),
             [Some('|'), ..] => self.advance_by_and_emit(1, Token::Pipe),
             [Some('}'), ..] => self.advance_by_and_emit(1, Token::RightBrace),
+            [Some('@'), Some('['), ..] => self.advance_by_and_emit(2, Token::AtLeftSquare),
             //-------------------------------------------------------------------------------------
             // Numbers.
             //-------------------------------------------------------------------------------------
@@ -372,12 +373,17 @@ impl<'a> Lexer<'a> {
                     "import" => self.emit(Token::KwImport),
                     "let" => self.emit(Token::KwLet),
                     "match" => self.emit(Token::KwMatch),
+                    "panic" => self.emit(Token::KwPanic),
                     "provide" => self.emit(Token::KwProvide),
                     "pub" => self.emit(Token::KwPub),
+                    "require" => self.emit(Token::KwRequire),
                     "return" => self.emit(Token::KwReturn),
-                    "self" => self.emit(Token::KwSelf),
+                    "todo" => self.emit(Token::KwTodo),
                     "transparent" => self.emit(Token::KwTransparent),
+                    "try" => self.emit(Token::KwTry),
                     "type" => self.emit(Token::KwType),
+                    "unimplemented" => self.emit(Token::KwUnimplemented),
+                    "unreachable" => self.emit(Token::KwUnreachable),
                     "use" => self.emit(Token::KwUse),
                     "with" => self.emit(Token::KwWith),
                     // If not a keyword then this must be an identifier.
@@ -729,6 +735,7 @@ mod tests {
         scan!("}", ok: Token::RightBrace);
         scan!("]", ok: Token::RightSquare);
         scan!(")", ok: Token::RightParen);
+        scan!("@[", ok: Token::AtLeftSquare);
         scan!("&&", ok: Token::AmpAmp);
         scan!("!", ok: Token::Bang);
         scan!("!=", ok: Token::BangEq);
@@ -916,12 +923,17 @@ mod tests {
         scan!("import", ok: Token::KwImport);
         scan!("let", ok: Token::KwLet);
         scan!("match", ok: Token::KwMatch);
+        scan!("panic", ok: Token::KwPanic);
         scan!("provide", ok: Token::KwProvide);
         scan!("pub", ok: Token::KwPub);
+        scan!("require", ok: Token::KwRequire);
         scan!("return", ok: Token::KwReturn);
-        scan!("self", ok: Token::KwSelf);
+        scan!("todo", ok: Token::KwTodo);
         scan!("transparent", ok: Token::KwTransparent);
+        scan!("try", ok: Token::KwTry);
         scan!("type", ok: Token::KwType);
+        scan!("unimplemented", ok: Token::KwUnimplemented);
+        scan!("unreachable", ok: Token::KwUnreachable);
         scan!("use", ok: Token::KwUse);
         scan!("with", ok: Token::KwWith);
     }

--- a/fuyu-core/src/parse/token.rs
+++ b/fuyu-core/src/parse/token.rs
@@ -39,18 +39,28 @@ pub enum Token {
     KwLet,
     /// The `match` keyword.
     KwMatch,
+    /// The `panic` keyword.
+    KwPanic,
     /// The `provide` keyword.
     KwProvide,
     /// The `pub` keyword.
     KwPub,
+    /// The `require` keyword.
+    KwRequire,
     /// The `return` keyword.
     KwReturn,
-    /// The `self` keyword.
-    KwSelf,
+    /// The `todo` keyword.
+    KwTodo,
     /// The `transparent` keyword.
     KwTransparent,
+    /// The `try` keyword.
+    KwTry,
     /// The `type` keyword.
     KwType,
+    /// The `unimplemented` keyword.
+    KwUnimplemented,
+    /// The `unreachable` keyword.
+    KwUnreachable,
     /// The `use` keyword.
     KwUse,
     /// The `with` keyword.
@@ -89,6 +99,8 @@ pub enum Token {
     RightSquare,
     /// `)`.
     RightParen,
+    /// `@[`
+    AtLeftSquare,
     /// `&&`.
     AmpAmp,
     /// `!`.

--- a/fuyuc/src/main.rs
+++ b/fuyuc/src/main.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! TODO: Module level docs.
-
 fn main() {
     println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
 }


### PR DESCRIPTION
Closes #55.

- Add `panic` keyword.
- Add `require` keyword.
- Add `todo` keyword.
- Add `try` keyword.
- Add `unimplemented` keyword.
- Add `unreachable` keyword.
- Add attributes (`@[...]`).
- Add optional function declaration body.
- Add spread operator for list construction.
- Change `as` to be after import for renaming.
- Remove `self` keyword.

<!--
Fuyu projects use a freeform pull request template, so we rely on contributors to read these brief instructions before submitting a pull request.

- If solving a bug or adding a feature, please submit an issue first that will be addressed by the pull request.
- Follow the Fuyu code conventions (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#code-conventions).
- Follow the pull request guidelines (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#pull-requests).
-->
