### PR TITLE
Change import, visibility, and match syntax

### DIFF
--- a/fuyu-core/src/ast/expr.rs
+++ b/fuyu-core/src/ast/expr.rs
@@ -21,7 +21,7 @@
 //! - Try expressions ([`TryExpr`]).
 //! - Let expressions ([`LetExpr`]).
 //! - Require expressions ([`RequireExpr`]).
-//! - Provide expressions ([`ProvideExpr`]).
+//! - Proof expressions ([`ProofExpr`]).
 //! - Return expressions ([`ReturnExpr`]).
 //! - Panic expressions ([`PanicExpr`]).
 //! - Todo expressions ([`TodoExpr`]).
@@ -76,17 +76,17 @@ pub enum Expr<'text> {
     Let(LetExpr<'text>),
     /// A require expression (refer to [`RequireExpr`]).
     Require(RequireExpr<'text>),
-    /// A provide expression (refer to [`ProvideExpr`]).
-    Provide(ProvideExpr<'text>),
+    /// A proof expression (refer to [`ProofExpr`]).
+    Proof(ProofExpr<'text>),
     /// A return expression (refer to [`ReturnExpr`]).
     Return(ReturnExpr<'text>),
-    /// A provide expression (refer to [`PanicExpr`]).
+    /// A panic expression (refer to [`PanicExpr`]).
     Panic(PanicExpr<'text>),
-    /// A provide expression (refer to [`TodoExpr`]).
+    /// A todo expression (refer to [`TodoExpr`]).
     Todo(TodoExpr<'text>),
-    /// A provide expression (refer to [`UnimplementedExpr`]).
+    /// An unimplemented expression (refer to [`UnimplementedExpr`]).
     Unimplemented(UnimplementedExpr<'text>),
-    /// A provide expression (refer to [`UnreachableExpr`]).
+    /// An unreachable expression (refer to [`UnreachableExpr`]).
     Unreachable(UnreachableExpr<'text>),
 }
 
@@ -557,12 +557,10 @@ pub struct IfClause<'text> {
 
 /// A match expression.
 ///
-/// This is part of a [`MatchExpr`].
-///
 /// # Form examples
 ///
 /// ```fuyu
-/// match value with {
+/// value match {
 ///     Some(x) if x > 10 => x,
 ///     Some(x) => 2 * x,
 ///     _ => 0,
@@ -585,7 +583,7 @@ pub struct MatchExpr<'text> {
 /// # Form examples
 ///
 /// ```fuyu
-/// match value with {
+/// value match {
 ///     Some(x) if x > 10 => x,
 /// //  ^^^^^^^^^^^^^^^^^^^^^^
 ///     Some(x) => 2 * x,
@@ -680,46 +678,46 @@ pub struct RequireExpr<'text> {
     pub expr: Box<Expr<'text>>,
 }
 
-/// A provide expression.
+/// A proof expression.
 ///
 /// # Form examples
 ///
 /// ```fuyu
-/// provide Emphasis => Strong;
-/// provide emphasis: Emphasis => Strong;
-/// provide (use a: A): B => B(10 * a.0);
-/// provide b_value(use a: A): B => B(10 * a.0);
-/// provide (use A): B => something_that_uses();
+/// proof Emphasis = Strong;
+/// proof emphasis: Emphasis = Strong;
+/// proof (use a: A): B = B(a.0);
+/// proof b_value(use a: A): B = B(a.0);
+/// proof (use A): B = B(1000);
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct ProvideExpr<'text> {
-    #[doc = docs!(span: "provision")]
+pub struct ProofExpr<'text> {
+    #[doc = docs!(span: "proof")]
     span: Span,
-    #[doc = docs!(name: "provision")]
+    #[doc = docs!(name: "proof")]
     pub ident: Option<Ident<'text>>,
-    #[doc = docs!(args: "provision")]
-    pub args: Vec<ProvideArg<'text>>,
-    #[doc = docs!(type_name: "provision")]
+    #[doc = docs!(args: "proof")]
+    pub args: Vec<ProofArg<'text>>,
+    #[doc = docs!(type_name: "proof")]
     pub type_name: TypeName<'text>,
-    #[doc = docs!(expr: "provisioned value")]
+    #[doc = docs!(expr: "proven value")]
     pub expr: Box<Expr<'text>>,
 }
 
-/// Implicit arguments to a provide declaration.
+/// Implicit arguments to a proof declaration.
 ///
-/// This is part of a [`ProvideExpr`].
+/// This is part of a [`ProofExpr`].
 ///
 /// # Form examples
 ///
 /// ```fuyu
-/// provide (use a: A): B => B(10 * a.0);
-/// //       ^^^^^^^^
-/// provide (use A): B => something_that_uses_a();
-/// //       ^^^^^
+/// proof (use a: A): B = B(a.0);
+/// //     ^^^^^^^^
+/// proof (use A): B = B(1000);
+/// //     ^^^^^
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct ProvideArg<'text> {
-    #[doc = docs!(span: "provision argument")]
+pub struct ProofArg<'text> {
+    #[doc = docs!(span: "proof argument")]
     span: Span,
     #[doc = docs!(name: "argument")]
     ident: Option<Ident<'text>>,

--- a/fuyu-core/src/ast/util.rs
+++ b/fuyu-core/src/ast/util.rs
@@ -77,9 +77,6 @@ macro_rules! docs {
     (rest_pattern) => {
         concat!("The rest (`..`) pattern.\n")
     };
-    (transparent) => {
-        concat!("Whether the declaration is annotated with `transparent`.\n")
-    };
     (type_name: $about:expr) => {
         concat!("The type name of the ", $about, ".\n")
     };
@@ -88,9 +85,6 @@ macro_rules! docs {
     };
     (using) => {
         concat!("Whether an argument is annotated with `use`.\n")
-    };
-    (visibility) => {
-        concat!("The visibility level of the declaration.\n")
     };
     // The `@list` takes a list of strings and formats them in proper English.
     (@list: $a:expr) => {

--- a/fuyu-core/src/parse/lexer.rs
+++ b/fuyu-core/src/parse/lexer.rs
@@ -366,26 +366,23 @@ impl<'a> Lexer<'a> {
                     // Keywords.
                     "as" => self.emit(Token::KwAs),
                     "const" => self.emit(Token::KwConst),
-                    "extern" => self.emit(Token::KwExtern),
                     "fn" => self.emit(Token::KwFn),
+                    "for" => self.emit(Token::KwFor),
                     "if" => self.emit(Token::KwIf),
                     "immediate" => self.emit(Token::KwImmediate),
                     "import" => self.emit(Token::KwImport),
                     "let" => self.emit(Token::KwLet),
                     "match" => self.emit(Token::KwMatch),
                     "panic" => self.emit(Token::KwPanic),
-                    "provide" => self.emit(Token::KwProvide),
-                    "pub" => self.emit(Token::KwPub),
+                    "proof" => self.emit(Token::KwProof),
                     "require" => self.emit(Token::KwRequire),
                     "return" => self.emit(Token::KwReturn),
                     "todo" => self.emit(Token::KwTodo),
-                    "transparent" => self.emit(Token::KwTransparent),
                     "try" => self.emit(Token::KwTry),
                     "type" => self.emit(Token::KwType),
                     "unimplemented" => self.emit(Token::KwUnimplemented),
                     "unreachable" => self.emit(Token::KwUnreachable),
                     "use" => self.emit(Token::KwUse),
-                    "with" => self.emit(Token::KwWith),
                     // If not a keyword then this must be an identifier.
                     "_" => self.emit(Token::Underscore),
                     ident => {
@@ -916,26 +913,23 @@ mod tests {
     fn scan_keywords() {
         scan!("as", ok: Token::KwAs);
         scan!("const", ok: Token::KwConst);
-        scan!("extern", ok: Token::KwExtern);
         scan!("fn", ok: Token::KwFn);
+        scan!("for", ok: Token::KwFor);
         scan!("if", ok: Token::KwIf);
         scan!("immediate", ok: Token::KwImmediate);
         scan!("import", ok: Token::KwImport);
         scan!("let", ok: Token::KwLet);
         scan!("match", ok: Token::KwMatch);
         scan!("panic", ok: Token::KwPanic);
-        scan!("provide", ok: Token::KwProvide);
-        scan!("pub", ok: Token::KwPub);
+        scan!("proof", ok: Token::KwProof);
         scan!("require", ok: Token::KwRequire);
         scan!("return", ok: Token::KwReturn);
         scan!("todo", ok: Token::KwTodo);
-        scan!("transparent", ok: Token::KwTransparent);
         scan!("try", ok: Token::KwTry);
         scan!("type", ok: Token::KwType);
         scan!("unimplemented", ok: Token::KwUnimplemented);
         scan!("unreachable", ok: Token::KwUnreachable);
         scan!("use", ok: Token::KwUse);
-        scan!("with", ok: Token::KwWith);
     }
 
     #[test]

--- a/fuyu-core/src/parse/token.rs
+++ b/fuyu-core/src/parse/token.rs
@@ -25,10 +25,10 @@ pub enum Token {
     KwAs,
     /// The `const` keyword.
     KwConst,
-    /// The `extern` keyword.
-    KwExtern,
     /// The `fn` keyword.
     KwFn,
+    /// The `for` keyword.
+    KwFor,
     /// The `if` keyword.
     KwIf,
     /// The `immediate` keyword.
@@ -41,18 +41,14 @@ pub enum Token {
     KwMatch,
     /// The `panic` keyword.
     KwPanic,
-    /// The `provide` keyword.
-    KwProvide,
-    /// The `pub` keyword.
-    KwPub,
+    /// The `proof` keyword.
+    KwProof,
     /// The `require` keyword.
     KwRequire,
     /// The `return` keyword.
     KwReturn,
     /// The `todo` keyword.
     KwTodo,
-    /// The `transparent` keyword.
-    KwTransparent,
     /// The `try` keyword.
     KwTry,
     /// The `type` keyword.
@@ -63,8 +59,6 @@ pub enum Token {
     KwUnreachable,
     /// The `use` keyword.
     KwUse,
-    /// The `with` keyword.
-    KwWith,
     /// A binary literal integer prefixed with `0b`.
     BinInt,
     /// An octal literal integer prefixed with `0o`.


### PR DESCRIPTION
Update the tokens, lexer, and AST with the new syntax/semantics for imports, visibility, matches, and proofs.

- Closes #59.
  - Remove the `pub` keyword.
  - Remove the `transparent` keyword.
- Closes #60.
  - Change provide to proof.
- Closes #61.
  - Add the `for` keyword.
  - Remove the `extern` keyword.
- Closes #62.
  - Update import path kinds.
- Closes #63.
  - Change `match` to a post-fix expression.
  - Remove the `with` keyword.

<!--
Fuyu projects use a freeform pull request template, so we rely on contributors to read these brief instructions before submitting a pull request.

- If solving a bug or adding a feature, please submit an issue first that will be addressed by the pull request.
- Follow the Fuyu code conventions (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#code-conventions).
- Follow the pull request guidelines (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#pull-requests).
-->
