### PR TITLE
Full word keyords

### DIFF
--- a/fuyu-core/src/ast/decl.rs
+++ b/fuyu-core/src/ast/decl.rs
@@ -3,9 +3,9 @@
 //! Declarations are statements that can appear at the top level in a module. Currently, these are:
 //!
 //! - `import` declarations ([`ImportDecl`]).
-//! - `const` declarations ([`ConstDecl`]).
+//! - `constant` declarations ([`ConstantDecl`]).
 //! - `type` declarations ([`TypeDecl`]).
-//! - `fn` declarations ([`FnDecl`]).
+//! - `function` declarations ([`FunctionDecl`]).
 //! - `proof` declarations ([`ProofDecl`]).
 //!
 //! Each declaration has its own type, however, they are all part of [`Decl`], which is an enum
@@ -19,12 +19,12 @@ use crate::parse::Span;
 pub enum Decl<'text> {
     /// An import declaration (refer to [`ImportDecl`]).
     Import(ImportDecl<'text>),
-    /// A constant declaration (refer to [`ConstDecl`]).
-    Const(ConstDecl<'text>),
+    /// A constant declaration (refer to [`ConstantDecl`]).
+    Const(ConstantDecl<'text>),
     /// A type declaration (refer to [`TypeDecl`]).
     Type(TypeDecl<'text>),
-    /// A function declaration (refer to [`FnDecl`]).
-    Fn(FnDecl<'text>),
+    /// A function declaration (refer to [`FunctionDecl`]).
+    Function(FunctionDecl<'text>),
     /// A proof declaration (refer to [`ProofDecl`]).
     Proof(ProofDecl<'text>),
 }
@@ -154,10 +154,10 @@ pub enum ImportDeclItem<'text> {
 /// # Form examples
 ///
 /// ```fuyu
-/// const magic_number: Int = 123;
+/// constant magic_number: Int = 123;
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct ConstDecl<'text> {
+pub struct ConstantDecl<'text> {
     #[doc = docs!(span: "constant binding"; including: "`;`")]
     pub span: Span,
     #[doc = docs!(name: "constant binding")]
@@ -248,19 +248,19 @@ pub struct TypeDeclField<'text> {
 /// # Form examples
 ///
 /// ```fuyu
-/// fn f(value: Triple) {}
-/// fn f(named value: Triple) {}
-/// fn f(use named value: Triple) {}
-/// fn f(use named Triple(x, y, z): Triple) {}
+/// function f(value: Triple) {}
+/// function f(named value: Triple) {}
+/// function f(use named value: Triple) {}
+/// function f(use named Triple(x, y, z): Triple) {}
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct FnDecl<'text> {
+pub struct FunctionDecl<'text> {
     #[doc = docs!(span: "function declaration"; including: "`;`")]
     pub span: Span,
     #[doc = docs!(name: "function")]
     pub ident: Ident<'text>,
     #[doc = docs!(args: "function")]
-    pub args: Vec<FnDeclArg<'text>>,
+    pub args: Vec<FunctionDeclArg<'text>>,
     #[doc = docs!(return_type)]
     pub return_type: Option<TypeName<'text>>,
     #[doc = docs!(exprs: "function")]
@@ -276,17 +276,17 @@ pub struct FnDecl<'text> {
 /// # Form examples
 ///
 /// ```fuyu
-/// fn f(value: Triple) {}
-/// //  ^^^^^^^^^^^^^^
-/// fn f(named value: Triple) {}
-/// //  ^^^^^^^^^^^^^^^^^^^^
-/// fn f(use named value: Triple) {}
-/// //  ^^^^^^^^^^^^^^^^^^^^^^^^
-/// fn f(use named Triple(x, y, z): Triple) {}
-/// //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// function f(value: Triple) {}
+/// //         ^^^^^^^^^^^^^^
+/// function f(named value: Triple) {}
+/// //         ^^^^^^^^^^^^^^^^^^^^
+/// function f(use named value: Triple) {}
+/// //         ^^^^^^^^^^^^^^^^^^^^^^^^
+/// function f(use named Triple(x, y, z): Triple) {}
+/// //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct FnDeclArg<'text> {
+pub struct FunctionDeclArg<'text> {
     #[doc = docs!(span: "function declaration argument")]
     pub span: Span,
     #[doc = docs!(using)]

--- a/fuyu-core/src/ast/expr.rs
+++ b/fuyu-core/src/ast/expr.rs
@@ -10,7 +10,7 @@
 //! - Identifiers ([`IdentExpr`]).
 //! - The `immediate` keyword ([`ImmediateExpr`]).
 //! - Block expressions ([`BlockExpr`]).
-//! - Anonymous functions ([`FnExpr`]).
+//! - Anonymous functions ([`FunctionExpr`]).
 //! - Function calls ([`CallExpr`]).
 //! - Binary infix operations ([`InfixExpr`]).
 //! - Unary prefix operations ([`PrefixExpr`]).
@@ -52,8 +52,8 @@ pub enum Expr<'text> {
     Immediate(ImmediateExpr),
     /// A block expression (refer to [`BlockExpr`]).
     Block(BlockExpr<'text>),
-    /// Anonymous function (refer to [`FnExpr`]).
-    Fn(FnExpr<'text>),
+    /// Anonymous function (refer to [`FunctionExpr`]).
+    Function(FunctionExpr<'text>),
     /// Function call (refer to [`CallExpr`]).
     Call(CallExpr<'text>),
     /// A binary infix operation (refer to [`InfixExpr`]).
@@ -241,16 +241,16 @@ pub struct BlockExpr<'text> {
 /// # Form examples
 ///
 /// ```fuyu
-/// fn() {}
-/// fn(x) { x }
-/// fn(use ctx: Context, x: Int) -> Int { ctx.next(x) }
+/// function() {}
+/// function(x) { x }
+/// function(use ctx: Context, x: Int) -> Int { ctx.next(x) }
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct FnExpr<'text> {
+pub struct FunctionExpr<'text> {
     #[doc = docs!(span: "function")]
     pub span: Span,
     #[doc = docs!(args: "function")]
-    pub args: Vec<FnArg<'text>>,
+    pub args: Vec<FunctionArg<'text>>,
     #[doc = docs!(return_type)]
     pub return_type: Option<TypeName<'text>>,
     #[doc = docs!(exprs: "function")]
@@ -259,18 +259,18 @@ pub struct FnExpr<'text> {
 
 /// An argument in an anonymous function.
 ///
-/// This is part of a [`FnExpr`].
+/// This is part of a [`FunctionExpr`].
 ///
 /// # Form examples
 ///
 /// ```fuyu
-/// fn(x) { x }
+/// function(x) { x }
 /// // ^
-/// fn(use ctx: Context, x: Int) -> Int { ctx.next(x) }
+/// function(use ctx: Context, x: Int) -> Int { ctx.next(x) }
 /// // ^^^^^^^^^^^^^^^^  ^^^^^^
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct FnArg<'text> {
+pub struct FunctionArg<'text> {
     #[doc = docs!(span: "anonymous function argument")]
     pub span: Span,
     #[doc = docs!(using)]
@@ -304,7 +304,7 @@ pub struct CallExpr<'text> {
     #[doc = docs!(args: "function call")]
     pub args: Vec<CallArg<'text>>,
     #[doc = docs!(block_arg)]
-    pub block: Option<FnCallBlock<'text>>,
+    pub block: Option<FunctionCallBlock<'text>>,
 }
 
 /// An argument to a function call.
@@ -348,7 +348,7 @@ pub struct CallArg<'text> {
 /// //       ^^^^^^^^^^^^^
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct FnCallBlock<'text> {
+pub struct FunctionCallBlock<'text> {
     #[doc = docs!(span: "block"; including: "`{`", "`}`")]
     pub span: Span,
     #[doc = docs!(args: "block")]

--- a/fuyu-core/src/ast/ident.rs
+++ b/fuyu-core/src/ast/ident.rs
@@ -50,6 +50,7 @@ pub struct Ident<'text> {
 /// (a, Int, namespace::SomeType[a, b])
 /// a[b, c]
 /// _
+/// function(a, b)
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub enum TypeName<'text> {
@@ -68,5 +69,14 @@ pub enum TypeName<'text> {
         span: Span,
         #[doc = docs!(type_params)]
         params: Vec<Self>,
+    },
+    /// A function type.
+    Function {
+        #[doc = docs!(span: "type name tuple"; including: "`function(`", "`)`", "`->`")]
+        span: Span,
+        #[doc = docs!(type_names: "function arguments")]
+        params: Vec<Self>,
+        #[doc = docs!(return_type)]
+        return_type: Option<Box<Self>>,
     },
 }

--- a/fuyu-core/src/ast/util.rs
+++ b/fuyu-core/src/ast/util.rs
@@ -80,6 +80,9 @@ macro_rules! docs {
     (type_name: $about:expr) => {
         concat!("The type name of the ", $about, ".\n")
     };
+    (type_names: $about:expr) => {
+        concat!("The type names of the ", $about, ".\n")
+    };
     (type_params) => {
         concat!("The parameters to a type.\n")
     };

--- a/fuyu-core/src/parse/lexer.rs
+++ b/fuyu-core/src/parse/lexer.rs
@@ -363,8 +363,8 @@ impl<'a> Lexer<'a> {
                     // Keywords.
                     "and" => self.emit(Token::KwAnd),
                     "as" => self.emit(Token::KwAs),
-                    "const" => self.emit(Token::KwConst),
-                    "fn" => self.emit(Token::KwFn),
+                    "constant" => self.emit(Token::KwConstant),
+                    "function" => self.emit(Token::KwFunction),
                     "for" => self.emit(Token::KwFor),
                     "if" => self.emit(Token::KwIf),
                     "immediate" => self.emit(Token::KwImmediate),
@@ -910,8 +910,8 @@ mod tests {
     fn scan_keywords() {
         scan!("and", ok: Token::KwAnd);
         scan!("as", ok: Token::KwAs);
-        scan!("const", ok: Token::KwConst);
-        scan!("fn", ok: Token::KwFn);
+        scan!("constant", ok: Token::KwConstant);
+        scan!("function", ok: Token::KwFunction);
         scan!("for", ok: Token::KwFor);
         scan!("if", ok: Token::KwIf);
         scan!("immediate", ok: Token::KwImmediate);

--- a/fuyu-core/src/parse/token.rs
+++ b/fuyu-core/src/parse/token.rs
@@ -25,10 +25,10 @@ pub enum Token {
     KwAnd,
     /// The `as` keyword.
     KwAs,
-    /// The `const` keyword.
-    KwConst,
-    /// The `fn` keyword.
-    KwFn,
+    /// The `constant` keyword.
+    KwConstant,
+    /// The `function` keyword.
+    KwFunction,
     /// The `for` keyword.
     KwFor,
     /// The `if` keyword.


### PR DESCRIPTION
Keywords in the specification were changed to be full English keywords instead of abbreviations. The following keywords were renamed:

- Change `const` to `constant`.
- Change `fn` to `function`.

Closes #67.

<!--
Fuyu projects use a freeform pull request template, so we rely on contributors to read these brief instructions before submitting a pull request.

- If solving a bug or adding a feature, please submit an issue first that will be addressed by the pull request.
- Follow the Fuyu code conventions (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#code-conventions).
- Follow the pull request guidelines (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#pull-requests).
-->
