### PR TITLE
Lexer layout rule

### DIFF
--- a/fuyu-core/src/parse/lexer.rs
+++ b/fuyu-core/src/parse/lexer.rs
@@ -276,10 +276,10 @@ impl<'a> Lexer<'a> {
             [Some('['), ..] => self.advance_by_and_emit(1, Token::LeftSquare),
             [Some('\\'), ..] => self.advance_by_and_emit(1, Token::BackSlash),
             [Some(']'), ..] => self.advance_by_and_emit(1, Token::RightSquare),
-            [Some('{'), ..] => self.advance_by_and_emit(1, Token::LeftBrace),
+            [Some('{'), ..] => self.advance_by_and_emit(1, Token::LeftBrace(None)),
             [Some('|'), Some('|'), ..] => self.advance_by_and_emit(2, Token::PipePipe),
             [Some('|'), ..] => self.advance_by_and_emit(1, Token::Pipe),
-            [Some('}'), ..] => self.advance_by_and_emit(1, Token::RightBrace),
+            [Some('}'), ..] => self.advance_by_and_emit(1, Token::RightBrace(None)),
             //-------------------------------------------------------------------------------------
             // Numbers.
             //-------------------------------------------------------------------------------------
@@ -720,10 +720,10 @@ mod tests {
 
     #[test]
     fn scan_operators_and_punctuation() {
-        scan!("{", ok: Token::LeftBrace);
+        scan!("{", ok: Token::LeftBrace(None));
         scan!("[", ok: Token::LeftSquare);
         scan!("(", ok: Token::LeftParen);
-        scan!("}", ok: Token::RightBrace);
+        scan!("}", ok: Token::RightBrace(None));
         scan!("]", ok: Token::RightSquare);
         scan!(")", ok: Token::RightParen);
         scan!("&[", ok: Token::AmpLeftSquare);

--- a/fuyu-core/src/parse/token.rs
+++ b/fuyu-core/src/parse/token.rs
@@ -84,13 +84,21 @@ pub enum Token {
     /// The content is not checked for validity.
     RawString,
     /// `{`.
-    LeftBrace,
+    ///
+    /// The associated value is `None` if the brace appears in the source. When the brace is
+    /// inserted by the lexer, the value is `Some` with the 1-indexed indentation of the column
+    /// where the brace is inserted.
+    LeftBrace(Option<usize>),
     /// `[`.
     LeftSquare,
     /// `(`.
     LeftParen,
     /// `}`.
-    RightBrace,
+    ///
+    /// The associated value is `None` if the brace appears in the source. When the brace is
+    /// inserted by the lexer, the value is `Some` with the 1-indexed indentation of the column
+    /// of the matching automatically inserted [`LeftBrace`][Token::LeftBrace].
+    RightBrace(Option<usize>),
     /// `]`.
     RightSquare,
     /// `)`.


### PR DESCRIPTION
<!--
Fuyu projects use a freeform pull request template, so we rely on contributors to read these brief instructions before submitting a pull request.

- If solving a bug or adding a feature, please submit an issue first that will be addressed by the pull request.
- Follow the Fuyu code conventions (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#code-conventions).
- Follow the pull request guidelines (https://github.com/fuyulang/.github/blob/main/CONTRIBUTING.md#pull-requests).
-->

Implementation of the layout rule in the lexer to automatically insert `{`, `}`, and `;` tokens  based on indentation.

- Closes #70.


